### PR TITLE
Add capnp as required dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Installation
 ### Dependencies
 
  * [RocksDB](http://rocksdb.org/)
+ * [capnp-tool](https://capnproto.org/capnp-tool.html) 
 
 
 ### Build


### PR DESCRIPTION
capnp should be specified to be installed, otherwise building fails with:

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error { kind: Failed, description: "Error while trying to execute `capnp compile`: Failed: No such file or directory (os error 2).  Please verify that version 0.5.2 or higher of the capnp executable is installed on your system. See https://capnproto.org/install.html" }', ../src/libcore/result.rs:788
note: Run with `RUST_BACKTRACE=1` for a backtrace.

```