### PR TITLE
ignore intellij project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 target
 Cargo.lock
+
+**/*.iml
+.idea/


### PR DESCRIPTION
when developing with the awesome IJ plugin for rust it makes sense to exclude the project files as part of the project gitignore.