### PR TITLE
Use rust-rocksdb 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,7 @@ rustc-serialize= "0.3.19"
 stemmer = "0.3.2"
 unicode-normalization = "0.1.2"
 unicode-segmentation = "0.1.2"
-
-[dependencies.rocksdb]
-git = "https://github.com/spacejam/rust-rocksdb.git"
+rocksdb = "0.5.0"
 
 
 [build-dependencies]

--- a/tests/rocksdb.rs
+++ b/tests/rocksdb.rs
@@ -1,5 +1,5 @@
 extern crate rocksdb;
-use rocksdb::{DB, Writable};
+use rocksdb::{DB};
 
 #[test]
 fn rocksdb_works() {


### PR DESCRIPTION
With the 0.5.0 release of rust-rocksdb we don't need to pull it
directly from Github, but can use that version.