### PR TITLE
Add exact match filter for booleans and null 

### DIFF
--- a/repl-tests/ranges.noise
+++ b/repl-tests/ranges.noise
@@ -14,6 +14,16 @@ add {"_id":"four", "A":-3};
 "four"
 add {"_id":"five", "A":35};
 "five"
+add {"_id":"six", "A":true};
+"six"
+add {"_id":"seven", "A":false};
+"seven"
+add {"_id":"eight", "A":null};
+"eight"
+add {"_id":"nine", "boolarray":[true, true]};
+"nine"
+add {"_id":"ten", "boolarray":[false, true]};
+"ten"
 
 
 # Exact match number
@@ -103,4 +113,28 @@ find {A: >-10, A: <20};
 [
 "two",
 "four"
+]
+
+
+# Exact match boolean
+
+find {A: ==true};
+[
+"six"
+]
+
+find {A: ==false};
+[
+"seven"
+]
+
+find {A: ==null};
+[
+"eight"
+]
+
+find {boolarray: [==true]};
+[
+"nine",
+"ten"
 ]

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -329,7 +329,7 @@ impl RangeFilter {
 
 impl QueryRuntimeFilter for RangeFilter {
     fn first_result(&mut self, start: &DocResult) -> Option<DocResult> {
-        let mut value_key = self.kb.number_key_without_arraypath(start.seq);
+        let mut value_key = self.kb.number_key(start.seq);
 
         // NOTE vmx 2017-04-13: Iterating over keys is really similar to the
         // `DocResultIterator` in `snapshot.rs`. It should probablly be unified.

--- a/src/index.rs
+++ b/src/index.rs
@@ -287,7 +287,8 @@ impl Index {
     }
 
     fn compare_keys(a: &[u8], b: &[u8]) -> Ordering {
-        if a[0] == 'W' as u8 && b[0] == 'W' as u8 {
+        let value_prefixes = ['W', 'f', 'T', 'F', 'N'];
+        if value_prefixes.contains(&(a[0] as char)) && value_prefixes.contains(&(b[0] as char)) {
             let astr = unsafe {str::from_utf8_unchecked(&a)};
             let bstr = unsafe {str::from_utf8_unchecked(&b)};
             KeyBuilder::compare_keys(astr, bstr)

--- a/src/key_builder.rs
+++ b/src/key_builder.rs
@@ -82,6 +82,20 @@ impl KeyBuilder {
         string
     }
 
+    /// Build the index key that corresponds to a true, false or nulla primitive
+    pub fn bool_null_key(&self, prefix: char, seq: u64) -> String {
+        let mut string = String::with_capacity(100);
+        string.push(prefix);
+        for segment in &self.keypath {
+            string.push_str(&segment);
+        };
+        string.push('#');
+        string.push_str(&seq.to_string());
+
+        KeyBuilder::add_arraypath(&mut string, &self.arraypath);
+        string
+    }
+
 
     /// Builds a stemmed word key for the input word and seq, using the key_path and arraypath
     /// built up internally.

--- a/src/key_builder.rs
+++ b/src/key_builder.rs
@@ -68,8 +68,8 @@ impl KeyBuilder {
         str
     }
 
-    // Build the keypath for a number primitive without the arraypath
-    pub fn number_key_without_arraypath(&self, seq: u64) -> String {
+    /// Build the index key that corresponds to a number primitive
+    pub fn number_key(&self, seq: u64) -> String {
         let mut string = String::with_capacity(100);
         string.push('f');
         for segment in &self.keypath {
@@ -77,13 +77,7 @@ impl KeyBuilder {
         };
         string.push('#');
         string.push_str(&seq.to_string());
-        string
-    }
 
-    // Build the index key that corresponds to a number primitive
-    pub fn number_key(&self, seq: u64) -> String {
-        let mut string = String::with_capacity(100);
-        string.push_str(&self.number_key_without_arraypath(seq));
         KeyBuilder::add_arraypath(&mut string, &self.arraypath);
         string
     }
@@ -357,14 +351,22 @@ impl KeyBuilder {
     }
 
     pub fn compare_keys(akey: &str, bkey: &str) -> Ordering {
-        debug_assert!(akey.starts_with('W'));
-        debug_assert!(bkey.starts_with('W'));
+        debug_assert!(akey.starts_with('W') ||
+                      akey.starts_with('f') ||
+                      akey.starts_with('T') ||
+                      akey.starts_with('F') ||
+                      akey.starts_with('N'));
+        debug_assert!(bkey.starts_with('W') ||
+                      bkey.starts_with('f') ||
+                      bkey.starts_with('T') ||
+                      bkey.starts_with('F') ||
+                      bkey.starts_with('N'));
         let (apath_str, aseq_str, aarraypath_str) =
                 KeyBuilder::split_keypath_seq_arraypath_from_key(&akey);
         let (bpath_str, bseq_str, barraypath_str) =
                 KeyBuilder::split_keypath_seq_arraypath_from_key(&bkey);
 
-        match apath_str[1..].cmp(&bpath_str[1..]) {
+        match apath_str[0..].cmp(&bpath_str[0..]) {
             Ordering::Less => Ordering::Less,
             Ordering::Greater => Ordering::Greater,
             Ordering::Equal => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -673,6 +673,24 @@ impl<'a, 'c> Parser<'a, 'c> {
                                               Some(RangeOperator::Inclusive(num)),
                                               Some(RangeOperator::Inclusive(num))))
                 },
+                JsonValue::True => {
+                    Box::new(RangeFilter::new(&self.snapshot,
+                                              self.kb.clone(),
+                                              Some(RangeOperator::True),
+                                              Some(RangeOperator::True)))
+                },
+                JsonValue::False => {
+                    Box::new(RangeFilter::new(&self.snapshot,
+                                              self.kb.clone(),
+                                              Some(RangeOperator::False),
+                                              Some(RangeOperator::False)))
+                },
+                JsonValue::Null => {
+                    Box::new(RangeFilter::new(&self.snapshot,
+                                              self.kb.clone(),
+                                              Some(RangeOperator::Null),
+                                              Some(RangeOperator::Null)))
+                },
                 _ => panic!("Exact match on other JSON types is not yet implemented!"),
             };
             Ok(filter)


### PR DESCRIPTION
It's now possible to do exact match queries on booleans
and null. Examples:

    find {A: ==true};
    find {A: ==false};
    find {A: ==null};
    find {boolarray: [==true]};
