### PR TITLE
Fix limit when results aren't sorted or grouped

### DIFF
--- a/repl-tests/limit.noise
+++ b/repl-tests/limit.noise
@@ -1,0 +1,132 @@
+# limit clause tests
+
+drop target/tests/querytestlimit;
+create target/tests/querytestlimit;
+
+
+add {"_id":"1", "A": 6};
+"1"
+add {"_id":"2", "A": 6};
+"2"
+add {"_id":"3", "A": 4};
+"3"
+add {"_id":"4", "A": 4};
+"4"
+add {"_id":"5", "A": 1};
+"5"
+
+# "limit" tests with find clause only
+
+find {A: >= 1};
+[
+"1",
+"2",
+"3",
+"4",
+"5"
+]
+
+find {A: >= 1}
+limit 1;
+[
+"1"
+]
+
+find {A: >= 1}
+limit 3;
+[
+"1",
+"2",
+"3"
+]
+
+find {A: < 5};
+[
+"3",
+"4",
+"5"
+]
+
+find {A: < 5}
+limit 2;
+[
+"3",
+"4"
+]
+
+# "limit" tests with ordering
+
+find {A: > 3}
+order .A;
+[
+"4",
+"3",
+"2",
+"1"
+]
+
+find {A: > 3}
+order .A
+limit 1;
+[
+"3"
+]
+
+# "limit" tests with return
+
+find {A: >= 1}
+return .;
+[
+{"A":6,"_id":"1"},
+{"A":6,"_id":"2"},
+{"A":4,"_id":"3"},
+{"A":4,"_id":"4"},
+{"A":1,"_id":"5"}
+]
+
+find {A: >= 1}
+return .
+limit 1;
+[
+{"A":6,"_id":"1"}
+]
+
+find {A: >= 1}
+return .A;
+[
+6,
+6,
+4,
+4,
+1
+]
+
+find {A: >= 1}
+return .A
+limit 1;
+[
+6
+]
+
+# "limit" tests with return and ordering
+
+find {A: >= 1}
+order .A
+return .A;
+[
+1,
+4,
+4,
+6,
+6
+]
+
+find {A: >= 1}
+order .A
+return .A
+limit 3;
+[
+1,
+4,
+4
+]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -57,6 +57,15 @@ impl<'a, 'c> Parser<'a, 'c> {
         }
     }
 
+    fn consume_no_ws(&mut self, token: &str) -> bool {
+        if self.could_consume(token) {
+            self.offset += token.len();
+            true
+        } else {
+            false
+        }
+    }
+
 
     fn must_consume(&mut self, token: &str) -> Result<(), Error> {
         if self.could_consume(token) {
@@ -227,7 +236,7 @@ impl<'a, 'c> Parser<'a, 'c> {
     }
 
     fn consume_keypath(&mut self) -> Result<Option<ReturnPath>, Error> {
-        let key: String = if self.consume(".") {
+        let key: String = if self.consume_no_ws(".") {
             if self.consume("[") {
                 let key = try!(self.must_consume_string_literal());
                 try!(self.must_consume("]"));

--- a/src/query.rs
+++ b/src/query.rs
@@ -452,6 +452,10 @@ impl<'a> QueryResults<'a> {
                 }
             }
         } else {
+            if self.limit == 0 {
+                return None;
+            }
+            self.limit -= 1;
             let dr = match self.get_next_result() {
                 Some(dr) => dr,
                 None => return None,


### PR DESCRIPTION
Also changed syntax so that when specifying a return path with a `.`
there can be no whitespace between the `.` and the keypath. subsequent
dots in the path and brackets, etc, still can have whitespace.

This change is because when a limit clause is after a `return .` the
limit keyword is interpreted as the field name.