### PR TITLE
`limit 1` should return first result

### DIFF
--- a/repl-tests/limit.noise
+++ b/repl-tests/limit.noise
@@ -69,7 +69,7 @@ find {A: > 3}
 order .A
 limit 1;
 [
-"3"
+"4"
 ]
 
 # "limit" tests with return


### PR DESCRIPTION
When you have a certain condition which returns several results, then
`limit 1` should return the first one of those.