### PR TITLE
Add workaround to "only logical nots" limitation

### DIFF
--- a/query_language_reference.md
+++ b/query_language_reference.md
@@ -134,7 +134,7 @@ You can use logical not with parentheses to negate everything enclosed. This exa
 find {foo: == "bar", !(fab: == "baz" || fab: == "biz")}
 ```
 
-You cannot have every clause be negated. Query need at least one non-negated clauses.
+You cannot have every clause be negated as it's a very resource intensive operation. Query need at least one non-negated clauses.
 
 Illegal:
 
@@ -155,6 +155,14 @@ Illegal:
 ```
 find {foo ~= "waz" && !(foo: ~= "bar" && foo: !~= "baz"})
 ```
+
+Workarounds for this limitation are:
+
+ - Do a `find {}` and filter out the results in your application
+ - Add a field that will always match and use it in your condition. Example:
+   ```
+   find {alwaystrue: == true && foo: !~= "bar"}
+   ```
 
 ### Relevancy Scoring and Boosting
 

--- a/repl-tests/not.noise
+++ b/repl-tests/not.noise
@@ -4,29 +4,29 @@ drop target/tests/querytestnot;
 create target/tests/querytestnot;
 
 
-add {"_id":"1", "bar": "fox"};
+add {"_id":"1", "alwaystrue": true, "bar": "fox"};
 "1"
-add {"_id":"2", "bar": "quick fox"};
+add {"_id":"2", "alwaystrue": true, "bar": "quick fox"};
 "2"
-add {"_id":"3", "bar": "quick brown fox"};
+add {"_id":"3", "alwaystrue": true, "bar": "quick brown fox"};
 "3"
-add {"_id":"4", "bar": ["fox"]};
+add {"_id":"4", "alwaystrue": true, "bar": ["fox"]};
 "4"
-add {"_id":"5", "bar": ["quick fox"]};
+add {"_id":"5", "alwaystrue": true, "bar": ["quick fox"]};
 "5"
-add {"_id":"6", "bar": ["quick brown fox"]};
+add {"_id":"6", "alwaystrue": true, "bar": ["quick brown fox"]};
 "6"
-add {"_id":"7", "baz": ["fox"]};
+add {"_id":"7", "alwaystrue": true, "baz": ["fox"]};
 "7"
-add {"_id":"8", "baz": ["quick","fox"]};
+add {"_id":"8", "alwaystrue": true, "baz": ["quick","fox"]};
 "8"
-add {"_id":"9", "baz": ["quick","brown","fox"]};
+add {"_id":"9", "alwaystrue": true, "baz": ["quick","brown","fox"]};
 "9"
-add {"_id":"10", "baz": [["quick"],["brown"],["fox"]]};
+add {"_id":"10", "alwaystrue": true, "baz": [["quick"],["brown"],["fox"]]};
 "10"
-add {"_id":"11", "baz": [["brown"],["fox"]]};
+add {"_id":"11", "alwaystrue": true, "baz": [["brown"],["fox"]]};
 "11"
-add {"_id":"12", "baz": [["fox"]]};
+add {"_id":"12", "alwaystrue": true, "baz": [["fox"]]};
 "12"
 
 find {(bar: ~="fox" || bar: ~="brown") && (bar: !~="quick")}
@@ -143,6 +143,10 @@ find !{baz: [~="fox"]}
 return ._id ;
 Parse error: query cannot be made up of only logical not. Must have at least one match clause not negated.
 
+find {!(bar: ~="quick" || bar: [~="quick"] || baz: [~="quick"] || baz: [[~="quick"]])}
+return ._id ;
+Parse error: query cannot be made up of only logical not. Must have at least one match clause not negated.
+
 find !{baz: ~="fox"} && !{baz: =="foo"}
 return ._id ;
 Parse error: Logical not ("!") is nested inside of another logical not. This is not allowed.
@@ -150,3 +154,15 @@ Parse error: Logical not ("!") is nested inside of another logical not. This is 
 find {foo: =="bar"} && !{baz: !~="fox"}
 return ._id ;
 Parse error: Logical not ("!") is nested inside of another logical not. This is not allowed.
+
+# Workaround for unallowable expressions
+
+find {!(bar: ~="quick" || bar: [~="quick"] || baz: [~="quick"] || baz: [[~="quick"]]), alwaystrue: == true}
+return ._id ;
+[
+"1",
+"4",
+"7",
+"11",
+"12"
+]


### PR DESCRIPTION
You cannot have every clause be negated as it's a very resource intensive
operation. Query need at least one non-negated clauses. There are two
workarounds:

 - Do a `find {}` and filter out the results in your application
 - Add a field that will always match and use it in your condition. Example:

    find {alwaystrue: == true && foo: !~= "bar"}

Add this information to the language reference and the repl-tests.

Fixes #28.