### PR TITLE
Merge remote-tracking branch 'origin/refactor_key_builder.rs' into refactor_key_builder.rs

### DIFF
--- a/src/returnable.rs
+++ b/src/returnable.rs
@@ -353,7 +353,7 @@ impl Returnable for RetBind {
             let mut array = Vec::with_capacity(value_keys.len());
             for base_key in value_keys {
                 let mut kb = KeyBuilder::new();
-                kb.parse_value_key_path_only(KeyBuilder::value_key_path_only_from_str(&base_key));
+                kb.parse_kp_value_no_seq(KeyBuilder::kp_value_no_seq_from_str(&base_key));
 
                 if let Some(json) = fetcher.fetch(seq, &mut kb, &self.extra_rp) {
                     array.push(json);


### PR DESCRIPTION
Stop using “keypath” in function signatures and instead use “kp”. Use
constants for key prefixes instead of literals, giving one place to
look to what a key means. More consistent names for functions.