### PR TITLE
Use rust-rocksdb fork

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rustc-serialize = "0.3.19"
 stemmer = "0.3.2"
 unicode-normalization = "0.1.2"
 unicode-segmentation = "0.1.2"
-rocksdb = "0.6.0"
+rocksdb = { git = "https://github.com/vmx/rust-rocksdb", branch = "noise" }
 varint = "0.9.0"
 uuid = { version = "0.3", features = ["v4"] }
 


### PR DESCRIPTION
To get the spatial/R-tree stuff working, we need a fork of RocksDB.
As additional APIs are needed, we also need to keep a fork of
rust-rocksdb.

Switching to this fork also fixes #40.