### PR TITLE
Temporarily use upstream rust-rocksdb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rustc-serialize = "0.3.19"
 stemmer = "0.3.2"
 unicode-normalization = "0.1.2"
 unicode-segmentation = "0.1.2"
-rocksdb = { git = "https://github.com/vmx/rust-rocksdb", branch = "noise" }
+rocksdb = "0.8.1"
 varint = "0.9.0"
 uuid = { version = "0.3", features = ["v4"] }
 


### PR DESCRIPTION
Published Crates are not allowed to point to Github repositories
directly. All dependencies need to be published on crates.io or be
within the source tree.

Until I figured out the best approach I publish the crate with the
most recent upstream rust-rocksdb to unbreak the build.