### PR TITLE
Switch to RocksDB forks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rustc-serialize = "0.3.19"
 stemmer = "0.3.2"
 unicode-normalization = "0.1.2"
 unicode-segmentation = "0.1.2"
-rocksdb = "0.8.1"
+noise_search_deps_rocksdb = "0.1.0"
 varint = "0.9.0"
 uuid = { version = "0.3", features = ["v4"] }
 


### PR DESCRIPTION
In order to get the spatial indexing/querying working, we need a
fork of RocksDB (and the rust binding) that supports multidimensional
indexing (which is implemented as R-tree).

Note that this commits just lays out the ground work, the actual
implementaton of the spatial indexing/querying will follow.