### PR TITLE
Make keys containing a dollar sign `$` work

### DIFF
--- a/repl-tests/query_basic.noise
+++ b/repl-tests/query_basic.noise
@@ -333,4 +333,19 @@ return [._id, score()];
 ["1",1]
 ]
 
+# Dollar sign bug
+add {"_id":"17", "$A": true};
+"17"
+add {"_id":"18", "A$B": true};
+"18"
+
+find {"$A": == true};
+[
+"17"
+]
+
+find {"A$B": == true};
+[
+"18"
+]
 

--- a/src/key_builder.rs
+++ b/src/key_builder.rs
@@ -289,10 +289,11 @@ impl KeyBuilder {
         }
     }
 
-    // returns the unescaped segment as Segment and the escaped segment as a slice
+    // returns the unescaped segment as Segment and the escaped segment as a String
     pub fn parse_first_kp_value_segment(keypath: &str) -> Option<(Segment, String)> {
 
         let mut unescaped = String::with_capacity(50);
+        // The length of the escaped sequence. It always starts with a dot '.'
         let mut len_bytes = 1;
         let mut chars = keypath.chars();
 
@@ -301,7 +302,8 @@ impl KeyBuilder {
             Some('.') => {
                 loop {
                     match chars.next() {
-                        Some('\\') => {
+                        Some(backslash @ '\\') => {
+                            len_bytes += backslash.len_utf8();
                             if let Some(c) = chars.next() {
                                 len_bytes += c.len_utf8();
                                 unescaped.push(c);


### PR DESCRIPTION
When a key contained a dollar sign, there were crashes or wrong
results were returned. The problem was that the internal escaping
of the dollar sign wasn't correctly kept track of.