### PR TITLE
Change order clause order

### DIFF
--- a/query_language_reference.md
+++ b/query_language_reference.md
@@ -188,7 +188,7 @@ This will order `baz` ascending with default value of `1` if no `baz` value exis
 
 ```
 find {foo: == "bar"}
-order .baz asc default=1
+order .baz default=1 asc
 ```
 
 This will order `baz` ascending, for values of `baz` that are the same, those results are now ordered as `biz` ascending.


### PR DESCRIPTION
This change changes the recommend way of ordering the order clause

Instead of

    order .baz asc default=1

use

    order .baz default=1 asc

This makes the language more uniform. Paths with default values in
return values have the same shape (as they don't have an additional
asc/desc keyword).

This is related to #51.