### PR TITLE
Put default value within aggregate

### DIFF
--- a/query_language_reference.md
+++ b/query_language_reference.md
@@ -653,7 +653,7 @@ Query:
 
 ```
 find {foo: =="group2"}
-return [group(.baz order=asc) default="a", group(.bar order=desc) default="c", count()];
+return [group(.baz default="a" order=asc), group(.bar default="c" order=desc), count()];
 ```
 
 Results:

--- a/repl-tests/group.noise
+++ b/repl-tests/group.noise
@@ -95,13 +95,13 @@ add {"_id":"13", "foo":"group", "baz": "c"};
 "13"
 
 find {foo: =="group"}
-return {max: max(.bar) default=120};
+return {max: max(.bar default=120)};
 [
 {"max":120}
 ]
 
 find {foo: =="group"}
-return {max: max(.bar) default=1};
+return {max: max(.bar default=1)};
 [
 {"max":3}
 ]
@@ -167,7 +167,7 @@ add {"_id":"9", "foo":"group3", "baz": "a", "bar": "f"};
 "9"
 
 find {foo: =="group3"}
-return [group(.baz order=asc) default="a", group(.bar order=desc) default="c", count()];
+return [group(.baz default="a" order=asc), group(.bar default="c" order=desc), count()];
 [
 ["a","f",1],
 ["a","c",1],


### PR DESCRIPTION
Prior to this change, default values for aggregates were specified
as:

    max(.foo) default=5

The new syntax is putting the default value within the aggregate
function:

    max(.foo default=5)

This makes more sense as the default value is not a single value
for the `max()` function, but it is applied to every Keypath
*within* the `max()` function.

It is also more symmetrical to the default values for returns.
There it's also <Keypath> <space> <default>, e.g.:

    return .foo default=5

This is part of #51.