### PR TITLE
Update for Rust 1.35.0 and 1.37 beta.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["lib"]
 rustc-serialize = "0.3.24"
 stemmer = "0.3.2"
 unicode-normalization = "0.1.8"
-unicode-segmentation = "1.2.1"
+unicode-segmentation = "1.3.0"
 noise_search_deps_rocksdb = "0.1.1"
 varint = "0.9.0"
 uuid = { version = "0.7.4", features = ["v4"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,7 +35,7 @@ impl error::Error for Error {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::Parse(_) => None,
             Error::Shred(_) => None,
@@ -43,7 +43,7 @@ impl error::Error for Error {
             // patched to be based on the std::error::Error trait
             Error::Rocks(_) => None,
             Error::Write(_) => None,
-            Error::Io(ref err) => Some(err as &error::Error),
+            Error::Io(ref err) => Some(err as &dyn error::Error),
         }
     }
 }

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -742,13 +742,13 @@ impl QueryRuntimeFilter for DistanceFilter {
 
 
 pub struct AndFilter<'a> {
-    filters: Vec<Box<QueryRuntimeFilter + 'a>>,
+    filters: Vec<Box<dyn QueryRuntimeFilter + 'a>>,
     current_filter: usize,
     array_depth: usize,
 }
 
 impl<'a> AndFilter<'a> {
-    pub fn new(filters: Vec<Box<QueryRuntimeFilter + 'a>>, array_depth: usize) -> AndFilter<'a> {
+    pub fn new(filters: Vec<Box<dyn QueryRuntimeFilter + 'a>>, array_depth: usize) -> AndFilter<'a> {
         AndFilter {
             filters: filters,
             current_filter: 0,
@@ -833,7 +833,7 @@ impl<'a> QueryRuntimeFilter for AndFilter<'a> {
 /// returned to caller. Because we won't know which side gets returned until both sides are
 /// fetched.
 pub struct FilterWithResult<'a> {
-    filter: Box<QueryRuntimeFilter + 'a>,
+    filter: Box<dyn QueryRuntimeFilter + 'a>,
     result: Option<DocResult>,
     is_done: bool,
     array_depth: usize,
@@ -888,8 +888,8 @@ pub struct OrFilter<'a> {
 }
 
 impl<'a> OrFilter<'a> {
-    pub fn new(left: Box<QueryRuntimeFilter + 'a>,
-               right: Box<QueryRuntimeFilter + 'a>,
+    pub fn new(left: Box<dyn QueryRuntimeFilter + 'a>,
+               right: Box<dyn QueryRuntimeFilter + 'a>,
                array_depth: usize)
                -> OrFilter<'a> {
         OrFilter {
@@ -983,14 +983,14 @@ impl<'a> QueryRuntimeFilter for OrFilter<'a> {
 
 pub struct NotFilter<'a> {
     iter: DBIterator,
-    filter: Box<QueryRuntimeFilter + 'a>,
+    filter: Box<dyn QueryRuntimeFilter + 'a>,
     last_doc_returned: Option<DocResult>,
     kb: KeyBuilder,
 }
 
 impl<'a> NotFilter<'a> {
     pub fn new(snapshot: &Snapshot,
-               filter: Box<QueryRuntimeFilter + 'a>,
+               filter: Box<dyn QueryRuntimeFilter + 'a>,
                kb: KeyBuilder)
                -> NotFilter<'a> {
         NotFilter {
@@ -1101,7 +1101,7 @@ impl<'a> QueryRuntimeFilter for NotFilter<'a> {
 
 pub struct BindFilter<'a> {
     bind_var_name: String,
-    filter: Box<QueryRuntimeFilter + 'a>,
+    filter: Box<dyn QueryRuntimeFilter + 'a>,
     array_depth: usize,
     kb: KeyBuilder,
     option_next: Option<DocResult>,
@@ -1109,7 +1109,7 @@ pub struct BindFilter<'a> {
 
 impl<'a> BindFilter<'a> {
     pub fn new(bind_var_name: String,
-               filter: Box<QueryRuntimeFilter + 'a>,
+               filter: Box<dyn QueryRuntimeFilter + 'a>,
                kb: KeyBuilder)
                -> BindFilter {
         BindFilter {
@@ -1185,12 +1185,12 @@ impl<'a> QueryRuntimeFilter for BindFilter<'a> {
 }
 
 pub struct BoostFilter<'a> {
-    filter: Box<QueryRuntimeFilter + 'a>,
+    filter: Box<dyn QueryRuntimeFilter + 'a>,
     boost: f32,
 }
 
 impl<'a> BoostFilter<'a> {
-    pub fn new(filter: Box<QueryRuntimeFilter + 'a>, boost: f32) -> BoostFilter {
+    pub fn new(filter: Box<dyn QueryRuntimeFilter + 'a>, boost: f32) -> BoostFilter {
         BoostFilter {
             filter: filter,
             boost: boost,

--- a/src/json_shred.rs
+++ b/src/json_shred.rs
@@ -208,7 +208,7 @@ impl Shredder {
         let key = self.kb.kp_value_no_seq();
         let mut buffer = Vec::with_capacity(value.len() + 1);
         buffer.push(code as u8);
-        try!((&mut buffer as &mut Write).write_all(value));
+        try!((&mut buffer as &mut dyn Write).write_all(value));
         self.shredded_key_values.insert(key, buffer);
         Ok(())
     }

--- a/src/json_value.rs
+++ b/src/json_value.rs
@@ -125,7 +125,7 @@ impl JsonValue {
         }
     }
 
-    pub fn render(&self, write: &mut Write, pretty: &mut PrettyPrint) -> Result<(), Error> {
+    pub fn render(&self, write: &mut dyn Write, pretty: &mut PrettyPrint) -> Result<(), Error> {
         match self {
             &JsonValue::Number(ref num) => {
                 try!(write.write_all(pretty.prefix()));

--- a/src/query.rs
+++ b/src/query.rs
@@ -171,11 +171,11 @@ pub struct QueryScoringInfo {
 }
 
 pub struct QueryResults<'a> {
-    filter: Box<QueryRuntimeFilter + 'a>,
+    filter: Box<dyn QueryRuntimeFilter + 'a>,
     doc_result_next: DocResult,
     snapshot: Rc<Snapshot<'a>>,
     fetcher: JsonFetcher,
-    returnable: Box<Returnable>,
+    returnable: Box<dyn Returnable>,
     needs_ordering_and_ags: bool,
     done_with_ordering_and_ags: bool,
     does_group_or_aggr: bool,
@@ -234,7 +234,7 @@ impl<'a> QueryResults<'a> {
         } else if has_ordering {
             returnable.take_order_for_matching_fields(&mut orders);
             if !orders.is_empty() {
-                let mut vec: Vec<Box<Returnable>> = Vec::new();
+                let mut vec: Vec<Box<dyn Returnable>> = Vec::new();
                 for (_key, order_info) in orders.into_iter() {
                     let order = order_info.clone();
                     match order_info.field {

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -18,7 +18,7 @@ fn is_command(str: &str) -> bool {
 }
 
 
-fn next_command(r: &mut BufRead, w: &mut Write, test_mode: bool) -> Option<String> {
+fn next_command(r: &mut dyn BufRead, w: &mut dyn Write, test_mode: bool) -> Option<String> {
     let mut lines = String::new();
     loop {
         // read in command until we get to a end semi-colon
@@ -67,7 +67,7 @@ fn next_command(r: &mut BufRead, w: &mut Write, test_mode: bool) -> Option<Strin
     }
 }
 
-pub fn repl(r: &mut BufRead, w: &mut Write, test_mode: bool) {
+pub fn repl(r: &mut dyn BufRead, w: &mut dyn Write, test_mode: bool) {
     let mut pretty = PrettyPrint::new("", "", "");
     loop {
         if let Some(cmd) = next_command(r, w, test_mode) {
@@ -110,7 +110,7 @@ pub fn repl(r: &mut BufRead, w: &mut Write, test_mode: bool) {
     }
 }
 
-fn flush_batch(index: &mut Index, batch: &mut Batch, w: &mut Write) {
+fn flush_batch(index: &mut Index, batch: &mut Batch, w: &mut dyn Write) {
     let mut batch2 = Batch::new();
     mem::swap(batch, &mut batch2);
     if let Err(reason) = index.flush(batch2) {
@@ -119,8 +119,8 @@ fn flush_batch(index: &mut Index, batch: &mut Batch, w: &mut Write) {
 }
 
 fn repl_opened(mut index: Index,
-               r: &mut BufRead,
-               w: &mut Write,
+               r: &mut dyn BufRead,
+               w: &mut dyn Write,
                test_mode: bool,
                mut pretty: PrettyPrint) {
     let mut batch = Batch::new();

--- a/src/returnable.rs
+++ b/src/returnable.rs
@@ -111,7 +111,7 @@ pub trait Returnable {
 
 /// A static Json Object the can contain another number of fields and nested returnables.
 pub struct RetObject {
-    pub fields: Vec<(String, Box<Returnable>)>,
+    pub fields: Vec<(String, Box<dyn Returnable>)>,
 }
 
 impl Returnable for RetObject {
@@ -155,7 +155,7 @@ impl Returnable for RetObject {
 
 /// A static Json array the can contain another number of nested Returnables.
 pub struct RetArray {
-    pub slots: Vec<Box<Returnable>>,
+    pub slots: Vec<Box<dyn Returnable>>,
 }
 
 impl Returnable for RetArray {
@@ -200,8 +200,8 @@ impl Returnable for RetArray {
 /// A special returnable that only fetches values for later ordering but never renders
 /// them back to the caller.
 pub struct RetHidden {
-    pub unrendered: Vec<Box<Returnable>>,
-    pub visible: Box<Returnable>,
+    pub unrendered: Vec<Box<dyn Returnable>>,
+    pub visible: Box<dyn Returnable>,
 }
 
 impl Returnable for RetHidden {


### PR DESCRIPTION
Traits without ``dyn`` syntax is deprecated.

https://doc.rust-lang.org/stable/edition-guide/rust-2018/trait-system/dyn-trait-for-trait-objects.html