### PR TITLE
errors: Fix a warning with description() being deprecated.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -22,19 +22,6 @@ impl PartialEq for Error {
 }
 
 impl error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::Parse(ref description) => description,
-            Error::Shred(ref description) => description,
-            // XXX vmx 2016-11-07: It should be fixed on the RocksDB wrapper
-            // that it has the std::error:Error implemented and hence
-            // and err.description()
-            Error::Rocks(_) => "This is an rocksdb error",
-            Error::Write(ref description) => description,
-            Error::Io(ref err) => err.description(),
-        }
-    }
-
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::Parse(_) => None,


### PR DESCRIPTION
Since it's deprecated, we don't need to implement it either.

warning: use of deprecated item 'std::error::Error::description': use the Display impl or to_string()
  --> src/error.rs:34:39
   |
34 |             Error::Io(ref err) => err.description(),
   |                                       ^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default