### PR TITLE
refactor: update to Rust edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 description = "Nested Object Inverted Search Engine"
 build = "build.rs"
+edition = "2021"
 
 [lib]
 name = "noise_search"

--- a/src/aggregates.rs
+++ b/src/aggregates.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 
-use json_value::JsonValue;
+use crate::json_value::JsonValue;
 
 pub type AggregateInitFun = fn(JsonValue) -> JsonValue;
 pub type AggregateActionFun = fn(&mut JsonValue, JsonValue, Option<&JsonValue>);

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -9,12 +9,12 @@ use std::{self, mem, str};
 
 use self::varint::VarintRead;
 
-use error::Error;
-use json_value::JsonValue;
-use key_builder::KeyBuilder;
-use query::{DocResult, QueryScoringInfo};
+use crate::error::Error;
+use crate::json_value::JsonValue;
+use crate::key_builder::KeyBuilder;
+use crate::query::{DocResult, QueryScoringInfo};
+use crate::snapshot::{AllDocsIterator, DocResultIterator, JsonFetcher, Scorer, Snapshot};
 use rocksdb::{self, DBIterator, IteratorMode};
-use snapshot::{AllDocsIterator, DocResultIterator, JsonFetcher, Scorer, Snapshot};
 
 pub trait QueryRuntimeFilter {
     fn first_result(&mut self, start: &DocResult) -> Option<DocResult>;

--- a/src/index.rs
+++ b/src/index.rs
@@ -20,11 +20,11 @@ use rocksdb::{
     Snapshot as RocksSnapshot,
 };
 
-use error::Error;
-use json_shred::{KeyValues, Shredder};
-use key_builder::{self, KeyBuilder};
-use query::QueryResults;
-use snapshot::Snapshot;
+use crate::error::Error;
+use crate::json_shred::{KeyValues, Shredder};
+use crate::key_builder::{self, KeyBuilder};
+use crate::query::QueryResults;
+use crate::snapshot::Snapshot;
 
 const NOISE_HEADER_VERSION: u64 = 1;
 
@@ -418,8 +418,8 @@ unsafe impl<T> Sync for MvccRwLock<T> {}
 mod tests {
     extern crate rocksdb;
     use super::{Batch, Index, MvccRwLock, OpenOptions};
-    use json_value::JsonValue;
-    use snapshot::JsonFetcher;
+    use crate::json_value::JsonValue;
+    use crate::snapshot::JsonFetcher;
     use std::str;
     use std::sync::mpsc::channel;
     use std::sync::Arc;

--- a/src/json_shred.rs
+++ b/src/json_shred.rs
@@ -11,10 +11,10 @@ use std::{self, f64, str};
 use self::rustc_serialize::json::{JsonEvent, Parser, StackElement};
 use self::varint::VarintWrite;
 
-use error::Error;
-use index::Index;
-use key_builder::KeyBuilder;
-use stems::Stems;
+use crate::error::Error;
+use crate::index::Index;
+use crate::key_builder::KeyBuilder;
+use crate::stems::Stems;
 
 // Good example of using rustc_serialize:
 //   https://github.com/ajroetker/beautician/blob/master/src/lib.rs
@@ -591,9 +591,9 @@ mod tests {
     use std::io::Cursor;
     use std::str;
 
-    use index::{Index, OpenOptions};
-    use json_value::JsonValue;
-    use snapshot::JsonFetcher;
+    use crate::index::{Index, OpenOptions};
+    use crate::json_value::JsonValue;
+    use crate::snapshot::JsonFetcher;
 
     fn positions_from_rocks(rocks: &rocksdb::DB) -> Vec<(String, Vec<u32>)> {
         let mut result = Vec::new();

--- a/src/json_value.rs
+++ b/src/json_value.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 use std::io::Write;
 use std::str;
 
-use error::Error;
+use crate::error::Error;
 
 #[derive(PartialEq, Clone, Debug)]
 pub enum JsonValue {

--- a/src/key_builder.rs
+++ b/src/key_builder.rs
@@ -1,7 +1,7 @@
 extern crate unicode_normalization;
 extern crate varint;
 
-use query::DocResult;
+use crate::query::DocResult;
 use std::cmp::Ordering;
 use std::io::Cursor;
 use std::str;
@@ -553,7 +553,7 @@ impl Default for KeyBuilder {
 #[cfg(test)]
 mod tests {
     use super::KeyBuilder;
-    use query::DocResult;
+    use crate::query::DocResult;
 
     #[test]
     fn test_segments_push() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,27 +1,26 @@
 #![allow(clippy::collapsible_else_if)]
 
-use std;
 use std::collections::HashMap;
 use std::iter::Iterator;
 use std::rc::Rc;
 use std::str;
 use std::usize;
 
-use aggregates::AggregateFun;
-use error::Error;
-use filters::{
+use crate::aggregates::AggregateFun;
+use crate::error::Error;
+use crate::filters::{
     AllDocsFilter, AndFilter, BboxFilter, BindFilter, BoostFilter, DistanceFilter,
     ExactMatchFilter, NotFilter, OrFilter, QueryRuntimeFilter, RangeFilter, RangeOperator,
     StemmedPhraseFilter, StemmedWordFilter, StemmedWordPosFilter,
 };
-use json_value::JsonValue;
-use key_builder::KeyBuilder;
-use query::{Order, OrderField, OrderInfo};
-use returnable::{
+use crate::json_value::JsonValue;
+use crate::key_builder::KeyBuilder;
+use crate::query::{Order, OrderField, OrderInfo};
+use crate::returnable::{
     RetArray, RetBind, RetLiteral, RetObject, RetScore, RetValue, ReturnPath, Returnable,
 };
-use snapshot::Snapshot;
-use stems::Stems;
+use crate::snapshot::Snapshot;
+use crate::stems::Stems;
 
 /// A boost value of 1.0 is equal to no boosting.
 const NO_BOOST: f32 = 1.0;
@@ -1421,7 +1420,7 @@ mod tests {
 
     use super::Parser;
 
-    use index::{Index, OpenOptions};
+    use crate::index::{Index, OpenOptions};
     use std::collections::HashMap;
     use std::rc::Rc;
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -10,13 +10,13 @@ use std::str;
 use std::usize;
 
 use self::rustc_serialize::json::{JsonEvent, Parser as JsonParser, StackElement};
-use aggregates::{AggregateActionFun, AggregateExtractFun, AggregateFun, AggregateInitFun};
-use error::Error;
-use filters::QueryRuntimeFilter;
-use json_value::JsonValue;
-use parser::Parser;
-use returnable::{RetHidden, RetScore, RetValue, ReturnPath, Returnable};
-use snapshot::{JsonFetcher, Snapshot};
+use crate::aggregates::{AggregateActionFun, AggregateExtractFun, AggregateFun, AggregateInitFun};
+use crate::error::Error;
+use crate::filters::QueryRuntimeFilter;
+use crate::json_value::JsonValue;
+use crate::parser::Parser;
+use crate::returnable::{RetHidden, RetScore, RetValue, ReturnPath, Returnable};
+use crate::snapshot::{JsonFetcher, Snapshot};
 
 #[derive(Clone)]
 pub struct DocResult {
@@ -800,7 +800,7 @@ pub struct OrderInfo {
 mod tests {
     extern crate rustc_serialize;
 
-    use index::{Batch, Index, OpenOptions};
+    use crate::index::{Batch, Index, OpenOptions};
 
     #[test]
     fn test_query_hello_world() {

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,5 +1,5 @@
-use index::{Batch, Index, OpenOptions};
-use json_value::{JsonValue, PrettyPrint};
+use crate::index::{Batch, Index, OpenOptions};
+use crate::json_value::{JsonValue, PrettyPrint};
 
 use std::io::{BufRead, Write};
 use std::mem;

--- a/src/returnable.rs
+++ b/src/returnable.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 use std::collections::VecDeque;
 
-use aggregates::AggregateFun;
-use json_value::JsonValue;
-use key_builder::KeyBuilder;
-use query::OrderInfo;
-use snapshot::JsonFetcher;
+use crate::aggregates::AggregateFun;
+use crate::json_value::JsonValue;
+use crate::key_builder::KeyBuilder;
+use crate::query::OrderInfo;
+use crate::snapshot::JsonFetcher;
 
 #[derive(Clone)]
 pub enum PathSegment {

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -9,11 +9,11 @@ use std::mem::transmute;
 use std::str;
 
 use self::varint::VarintRead;
-use index::Index;
-use json_value::JsonValue;
-use key_builder::{KeyBuilder, Segment};
-use query::{DocResult, QueryScoringInfo};
-use returnable::{PathSegment, ReturnPath};
+use crate::index::Index;
+use crate::json_value::JsonValue;
+use crate::key_builder::{KeyBuilder, Segment};
+use crate::query::{DocResult, QueryScoringInfo};
+use crate::returnable::{PathSegment, ReturnPath};
 
 pub struct Snapshot<'a> {
     rocks: RocksSnapshot<'a>,


### PR DESCRIPTION
The update was done with `cargo fix --edition`, first to 2018 then to
2021 edition.

Also `cargo fmt` was run and Clippy warnings were fixed.