### PR TITLE
fix: fix Rust debug builds

### DIFF
--- a/src/filters.rs
+++ b/src/filters.rs
@@ -527,9 +527,12 @@ impl<'a> BboxFilter<'a> {
 
     /// Function to deserialize the Arraypaths
     fn from_u8_slice(slice: &[u8]) -> Vec<u64> {
-        let u64_slice =
-            unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const u64, slice.len() / 8) };
-        u64_slice.to_vec()
+        slice
+            .as_chunks::<8>()
+            .0
+            .iter()
+            .map(|chunk| u64::from_ne_bytes(*chunk))
+            .collect()
     }
 }
 


### PR DESCRIPTION
The tests were failing with:

    thread 'test_repl' (67668) panicked at src/filters.rs:531:22:
    unsafe precondition(s) violated: slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`

This commit replaces the unsafe code with safe code.