### PR TITLE
refactor: switch CursorBackend to a lending iterator

### DIFF
--- a/noise-storage-rocksdb/src/lib.rs
+++ b/noise-storage-rocksdb/src/lib.rs
@@ -5,8 +5,8 @@ use noise_storage::{
     BackendSnapshot, Cursor, CursorBackend, DatabaseConfig, Namespace, SeekFrom, StorageError,
 };
 use rocksdb::{
-    self, BlockBasedIndexType, BlockBasedOptions, CompactionDecision, IteratorMode, MergeOperands,
-    Snapshot as RocksDbSnapshot,
+    self, BlockBasedIndexType, BlockBasedOptions, CompactionDecision, DBRawIterator, IteratorMode,
+    MergeOperands, Snapshot as RocksDbSnapshot,
 };
 use self_cell::self_cell;
 
@@ -111,9 +111,9 @@ impl BackendDatabase for RocksDatabase {
     }
 
     fn iterator(&self) -> Cursor {
-        Cursor::new(Box::new(RocksCursor {
-            iter: self.db.iterator(IteratorMode::Start),
-        }))
+        Cursor::new(Box::new(RocksCursor::new(
+            self.db.iterator(IteratorMode::Start).into(),
+        )))
     }
 
     fn compact(&self) {
@@ -194,36 +194,69 @@ impl BackendSnapshot for RocksSnapshot {
     }
 
     fn iterator(&self) -> Cursor {
-        Cursor::new(Box::new(RocksCursor {
-            iter: self.borrow_dependent().iterator(IteratorMode::Start),
-        }))
+        Cursor::new(Box::new(RocksCursor::new(
+            self.borrow_dependent().iterator(IteratorMode::Start).into(),
+        )))
     }
 
     fn multidim_iterator(&self, query: &[u8]) -> Cursor {
-        Cursor::new(Box::new(RocksCursor {
-            iter: self.borrow_dependent().rtree_iterator(query),
-        }))
+        Cursor::new(Box::new(RocksCursor::new(
+            self.borrow_dependent().rtree_iterator(query).into(),
+        )))
     }
 }
 
+// Wraps `DBRawIterator` so we can hand back borrowed slices directly from the
+// rocksdb-owned buffer. The C++ iterator's contract is that `key()`/`value()`
+// slices are valid only until the next `next()`/`seek*()` call; the lending
+// signature `&mut self -> Option<(&[u8], &[u8])>` ties that contract into the
+// borrow checker, so the `unsafe` calls below are sound.
 struct RocksCursor {
-    iter: rocksdb::DBIterator,
+    iter: DBRawIterator,
+    /// Whether the iterator is already positioned on the entry that `next()`
+    /// should return, i.e. a seek happened with no `next()` since. The raw
+    /// iterator points *at* the current entry, so `next()` only advances it
+    /// when this is false.
+    just_seeked: bool,
+}
+
+impl RocksCursor {
+    fn new(iter: DBRawIterator) -> Self {
+        // A raw iterator obtained from a `DBIterator` is already positioned
+        // on the first entry, so the first `next()` must yield the current
+        // entry instead of advancing.
+        Self {
+            iter,
+            just_seeked: true,
+        }
+    }
 }
 
 impl CursorBackend for RocksCursor {
-    fn next(&mut self) -> Option<(Box<[u8]>, Box<[u8]>)> {
-        self.iter.next()
+    fn next(&mut self) -> Option<(&[u8], &[u8])> {
+        if self.just_seeked {
+            self.just_seeked = false;
+        } else if self.iter.valid() {
+            self.iter.next();
+        } else {
+            // Advancing an invalid iterator violates the rocksdb contract, so
+            // an exhausted cursor stays exhausted (until the next seek).
+            return None;
+        }
+        if !self.iter.valid() {
+            return None;
+        }
+        // SAFETY: the returned slices borrow from `&mut self`; the borrow
+        // checker forbids calling another `&mut self` method (next/seek)
+        // while they're held, which is exactly the rocksdb contract.
+        unsafe { Some((self.iter.key_inner()?, self.iter.value_inner()?)) }
     }
 
     fn seek(&mut self, from: SeekFrom) {
         match from {
-            SeekFrom::Start => {
-                self.iter.set_mode(IteratorMode::Start);
-            }
-            SeekFrom::Key(key) => {
-                self.iter
-                    .set_mode(IteratorMode::From(key, rocksdb::Direction::Forward));
-            }
+            SeekFrom::Start => self.iter.seek_to_first(),
+            SeekFrom::Key(key) => self.iter.seek(key),
         }
+        self.just_seeked = true;
     }
 }

--- a/noise-storage/src/lib.rs
+++ b/noise-storage/src/lib.rs
@@ -303,11 +303,8 @@ pub trait BackendSnapshot {
     fn multidim_iterator(&self, query: &[u8]) -> Cursor;
 }
 
-/// Key-value pair type returned by cursor iteration.
-pub type KvPair = (Box<[u8]>, Box<[u8]>);
-
 pub trait CursorBackend {
-    fn next(&mut self) -> Option<KvPair>;
+    fn next(&mut self) -> Option<(&[u8], &[u8])>;
     fn seek(&mut self, from: SeekFrom);
 }
 
@@ -323,12 +320,11 @@ impl Cursor {
     pub fn seek(&mut self, from: SeekFrom) {
         self.inner.seek(from);
     }
-}
 
-impl Iterator for Cursor {
-    type Item = (Box<[u8]>, Box<[u8]>);
-
-    fn next(&mut self) -> Option<Self::Item> {
+    // This is a lending iterator: the returned slices borrow from `&mut self`,
+    // which `std::iter::Iterator` can't express, hence no `Iterator` impl.
+    #[allow(clippy::should_implement_trait)]
+    pub fn next(&mut self) -> Option<(&[u8], &[u8])> {
         self.inner.next()
     }
 }

--- a/noise-tests/src/lib.rs
+++ b/noise-tests/src/lib.rs
@@ -41,9 +41,9 @@ pub fn seq_ordering<D: BackendDatabase>() {
     }
 
     let mut observed = Vec::new();
-    let iter = db.iterator();
-    for (key, _) in iter {
-        let key_str = std::str::from_utf8(&key).unwrap();
+    let mut iter = db.iterator();
+    while let Some((key, _)) = iter.next() {
+        let key_str = std::str::from_utf8(key).unwrap();
         if !key_str.starts_with('W') {
             continue;
         }

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -311,7 +311,7 @@ impl ExactMatchFilter {
 
             if let Some((key, value)) = self.iter.next() {
                 debug_assert!(key.starts_with(value_key.as_bytes())); // must always be true!
-                if let JsonValue::String(string) = JsonFetcher::bytes_to_json_value(&value) {
+                if let JsonValue::String(string) = JsonFetcher::bytes_to_json_value(value) {
                     let matches = if self.case_sensitive {
                         self.phrase == string
                     } else {
@@ -424,13 +424,13 @@ impl QueryRuntimeFilter for RangeFilter {
     }
 
     fn next_result(&mut self) -> Option<DocResult> {
-        for (key, value) in &mut self.iter {
+        while let Some((key, value)) = self.iter.next() {
             if !key.starts_with(self.keypath.as_bytes()) {
                 // we passed the key path we are interested in. nothing left to do
                 return None;
             }
 
-            let key_str = unsafe { str::from_utf8_unchecked(&key) };
+            let key_str = unsafe { str::from_utf8_unchecked(key) };
 
             // The key already matched, hence it's a valid doc result. Return it.
             if self.min == Some(RangeOperator::True)
@@ -541,7 +541,7 @@ impl<S: BackendSnapshot> QueryRuntimeFilter for BboxFilter<S> {
         let iter = self.iter.as_mut().unwrap();
         if let Some((key, value)) = iter.next() {
             let mut vec = Vec::with_capacity(key.len());
-            vec.extend_from_slice(&key);
+            vec.extend_from_slice(key);
             let mut read = Cursor::new(vec);
             let key_len = read.read_unsigned_varint_32().unwrap();
             let offset = read.position() as usize;
@@ -553,7 +553,7 @@ impl<S: BackendSnapshot> QueryRuntimeFilter for BboxFilter<S> {
 
             let mut dr = DocResult::new();
             dr.seq = iid;
-            dr.arraypath = Self::from_u8_slice(&value);
+            dr.arraypath = Self::from_u8_slice(value);
             if let Some(to) = self.term_ordinal {
                 dr.add_score(to, 1.0);
             }
@@ -967,7 +967,7 @@ impl NotFilter {
                 let value_key = self.kb.kp_value_key_from_doc_result(dr);
                 self.iter.seek(SeekFrom::Key(value_key.as_bytes()));
                 if let Some((key, _value)) = self.iter.next() {
-                    let key_str = unsafe { str::from_utf8_unchecked(&key) };
+                    let key_str = unsafe { str::from_utf8_unchecked(key) };
                     KeyBuilder::is_kp_value_key_prefix(&value_key, key_str)
                 } else {
                     false
@@ -985,7 +985,7 @@ impl NotFilter {
             let value_key = kb.kp_value_key_from_doc_result(dr);
             self.iter.seek(SeekFrom::Key(value_key.as_bytes()));
             if let Some((key, _value)) = self.iter.next() {
-                let key_str = unsafe { str::from_utf8_unchecked(&key) };
+                let key_str = unsafe { str::from_utf8_unchecked(key) };
                 value_key == key_str
             } else {
                 false

--- a/src/index.rs
+++ b/src/index.rs
@@ -163,11 +163,11 @@ impl<D: BackendDatabase> Index<D> {
             let mut iter = self.db.iterator();
             // Seek in index to >= entry
             iter.seek(SeekFrom::Key(value_key.as_bytes()));
-            for (key, value) in iter {
+            while let Some((key, value)) = iter.next() {
                 if !key.starts_with(value_key.as_bytes()) {
                     break;
                 }
-                let key = unsafe { str::from_utf8_unchecked(&key) }.to_string();
+                let key = unsafe { str::from_utf8_unchecked(key) }.to_string();
                 let value = value.to_vec();
                 key_values.insert(key, value);
             }
@@ -191,8 +191,9 @@ impl<D: BackendDatabase> Index<D> {
 
     pub fn all_keys(&self) -> Result<Vec<String>, Error> {
         let mut results = Vec::new();
-        for (key, _value) in self.db.iterator() {
-            let key_string = unsafe { str::from_utf8_unchecked(&key) }.to_string();
+        let mut iter = self.db.iterator();
+        while let Some((key, _value)) = iter.next() {
+            let key_string = unsafe { str::from_utf8_unchecked(key) }.to_string();
             results.push(key_string);
         }
         Ok(results)
@@ -332,10 +333,11 @@ mod tests {
         index.flush(batch).unwrap();
         {
             let mut results = Vec::new();
-            for (key, value) in index.db.iterator() {
+            let mut iter = index.db.iterator();
+            while let Some((key, value)) = iter.next() {
                 if key[0] as char == 'V' {
-                    let key_string = unsafe { str::from_utf8_unchecked(&key) }.to_string();
-                    results.push((key_string, JsonFetcher::bytes_to_json_value(&value)));
+                    let key_string = unsafe { str::from_utf8_unchecked(key) }.to_string();
+                    results.push((key_string, JsonFetcher::bytes_to_json_value(value)));
                 }
             }
 
@@ -361,10 +363,11 @@ mod tests {
         index.flush(batch).unwrap();
 
         let mut results = Vec::new();
-        for (key, value) in index.db.iterator() {
+        let mut iter = index.db.iterator();
+        while let Some((key, value)) = iter.next() {
             if key[0] as char == 'V' {
-                let key_string = unsafe { str::from_utf8_unchecked(&key) }.to_string();
-                results.push((key_string, JsonFetcher::bytes_to_json_value(&value)));
+                let key_string = unsafe { str::from_utf8_unchecked(key) }.to_string();
+                results.push((key_string, JsonFetcher::bytes_to_json_value(value)));
             }
         }
         let expected = vec![

--- a/src/json_shred.rs
+++ b/src/json_shred.rs
@@ -590,7 +590,8 @@ mod tests {
 
     fn positions_from_db(db: &Database) -> Vec<(String, Vec<u32>)> {
         let mut result = Vec::new();
-        for (key, value) in db.iterator() {
+        let mut iter = db.iterator();
+        while let Some((key, value)) = iter.next() {
             if key[0] as char == 'W' {
                 let mut vec = Vec::with_capacity(value.len());
                 vec.extend(value.iter());
@@ -599,7 +600,7 @@ mod tests {
                 while let Ok(pos) = bytes.read_unsigned_varint_32() {
                     positions.push(pos);
                 }
-                let key_string = unsafe { str::from_utf8_unchecked(&key) }.to_string();
+                let key_string = unsafe { str::from_utf8_unchecked(key) }.to_string();
                 result.push((key_string, positions));
             }
         }
@@ -608,10 +609,11 @@ mod tests {
 
     fn values_from_db(db: &Database) -> Vec<(String, JsonValue)> {
         let mut result = Vec::new();
-        for (key, value) in db.iterator() {
+        let mut iter = db.iterator();
+        while let Some((key, value)) = iter.next() {
             if key[0] as char == 'V' {
-                let key_string = unsafe { str::from_utf8_unchecked(&key) }.to_string();
-                result.push((key_string, JsonFetcher::bytes_to_json_value(&value)));
+                let key_string = unsafe { str::from_utf8_unchecked(key) }.to_string();
+                result.push((key_string, JsonFetcher::bytes_to_json_value(value)));
             }
         }
         result

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -10,7 +10,43 @@ use crate::key_builder::{KeyBuilder, Segment};
 use crate::query::{DocResult, QueryScoringInfo};
 use crate::returnable::{PathSegment, ReturnPath};
 use noise_storage::{convert_bytes_to_i32, BackendSnapshot, Cursor, SeekFrom};
-use std::iter::Peekable;
+
+/// One-step lookahead over a `Cursor`. `Cursor::next` lends out slices that
+/// borrow from `&mut self`, so `Cursor` cannot implement `Iterator` and the
+/// standard `Peekable` adapter is not usable with it. `PeekCursor` provides
+/// the same lookahead by owning the peeked pair, so the borrow on the
+/// underlying cursor ends between `peek()` and the next operation.
+struct PeekCursor<'a> {
+    inner: &'a mut Cursor,
+    peeked: Option<(Vec<u8>, Vec<u8>)>,
+}
+
+impl<'a> PeekCursor<'a> {
+    fn new(inner: &'a mut Cursor) -> Self {
+        Self {
+            inner,
+            peeked: None,
+        }
+    }
+
+    fn peek(&mut self) -> Option<(&[u8], &[u8])> {
+        if self.peeked.is_none() {
+            if let Some((k, v)) = self.inner.next() {
+                self.peeked = Some((k.to_vec(), v.to_vec()));
+            }
+        }
+        self.peeked
+            .as_ref()
+            .map(|(k, v)| (k.as_slice(), v.as_slice()))
+    }
+
+    fn next(&mut self) -> Option<(Vec<u8>, Vec<u8>)> {
+        if let Some(pair) = self.peeked.take() {
+            return Some(pair);
+        }
+        self.inner.next().map(|(k, v)| (k.to_vec(), v.to_vec()))
+    }
+}
 
 pub struct Snapshot<S: BackendSnapshot> {
     snap: S,
@@ -84,7 +120,7 @@ impl DocResultIterator {
                 return None;
             }
 
-            let key_str = unsafe { str::from_utf8_unchecked(&key) };
+            let key_str = unsafe { str::from_utf8_unchecked(key) };
             let dr = KeyBuilder::parse_doc_result_from_kp_word_key(key_str);
 
             Some((
@@ -149,7 +185,7 @@ impl Scorer {
         self.iter.seek(SeekFrom::Key(key.as_bytes()));
         if let Some((ret_key, ret_value)) = self.iter.next() {
             if ret_key.len() == key.len() && ret_key.starts_with(key.as_bytes()) {
-                Some(ret_value)
+                Some(ret_value.to_vec().into_boxed_slice())
             } else {
                 None
             }
@@ -283,7 +319,7 @@ impl JsonFetcher {
         iter.seek(SeekFrom::Key(value_key.as_bytes()));
 
         let (key, value) = match iter.next() {
-            Some((key, value)) => (key, value),
+            Some((key, value)) => (key.to_vec(), value.to_vec()),
             None => return None,
         };
 
@@ -293,7 +329,7 @@ impl JsonFetcher {
             return None;
         }
         Some(JsonFetcher::do_fetch(
-            &mut iter.peekable(),
+            &mut PeekCursor::new(iter),
             &value_key,
             key,
             value,
@@ -306,10 +342,10 @@ impl JsonFetcher {
     /// depth first recursively parse the keypath and return the value and inserting into
     /// containers (arrays or objects) then iterate keys until the keypath no longer matches.
     fn do_fetch(
-        iter: &mut Peekable<&mut Cursor>,
+        iter: &mut PeekCursor<'_>,
         value_key: &str,
-        mut key: Box<[u8]>,
-        mut value: Box<[u8]>,
+        mut key: Vec<u8>,
+        mut value: Vec<u8>,
     ) -> JsonValue {
         if key.len() == value_key.len() {
             // we have a key match!
@@ -423,7 +459,7 @@ impl AllDocsIterator {
     pub fn next(&mut self) -> Option<DocResult> {
         match self.iter.next() {
             Some((k, _v)) => {
-                let key = unsafe { str::from_utf8_unchecked(&k) };
+                let key = unsafe { str::from_utf8_unchecked(k) };
                 if let Some(seq) = KeyBuilder::parse_seq_key(key) {
                     let mut dr = DocResult::new();
                     dr.seq = seq;


### PR DESCRIPTION
`CursorBackend::next` now returns `Option<(&[u8], &[u8])>` borrowing from `&mut self` instead of `Option<(Box<[u8]>, Box<[u8]>)>`, removing the per-step `Box<[u8]>` allocations and matching the rocksdb `key()`/`value()` contract.

* noise-storage-rocksdb wraps `DBRawIterator` (via `DBIterator::into()`) and reads keys/values through `key_inner`/`value_inner` in a localized `unsafe` block; the borrow checker enforces the "valid until the next next/seek" rule.
* `Cursor` no longer implements `Iterator`; callers switch `for (k, v) in cursor` to `while let Some((k, v)) = cursor.next()`.