### PR TITLE
refactor: drop PeekCursor by positioning the cursor

### DIFF
--- a/noise-storage-rocksdb/src/lib.rs
+++ b/noise-storage-rocksdb/src/lib.rs
@@ -206,50 +206,43 @@ impl BackendSnapshot for RocksSnapshot {
     }
 }
 
-// Wraps `DBRawIterator` so we can hand back borrowed slices directly from the
-// rocksdb-owned buffer. The C++ iterator's contract is that `key()`/`value()`
-// slices are valid only until the next `next()`/`seek*()` call; the lending
-// signature `&mut self -> Option<(&[u8], &[u8])>` ties that contract into the
-// borrow checker, so the `unsafe` calls below are sound.
+// Wraps `DBRawIterator`, which is always positioned *on* an entry (or invalid).
+// `key()`/`value()` borrow the C++ iterator's own buffers and are valid only
+// until the iterator moves. The positioned `current`/`advance` split ties that
+// contract into the borrow checker — `current` borrows `&self`, `advance`/`seek`
+// take `&mut self` — so a caller cannot move the iterator while holding a slice.
 struct RocksCursor {
     iter: DBRawIterator,
-    /// Whether the iterator is already positioned on the entry that `next()`
-    /// should return, i.e. a seek happened with no `next()` since. The raw
-    /// iterator points *at* the current entry, so `next()` only advances it
-    /// when this is false.
-    just_seeked: bool,
 }
 
 impl RocksCursor {
     fn new(iter: DBRawIterator) -> Self {
-        // A raw iterator obtained from a `DBIterator` is already positioned
-        // on the first entry, so the first `next()` must yield the current
-        // entry instead of advancing.
-        Self {
-            iter,
-            just_seeked: true,
-        }
+        // A raw iterator obtained from a `DBIterator` is already positioned on
+        // the first entry, so `current` is valid before any `seek`.
+        Self { iter }
     }
 }
 
 impl CursorBackend for RocksCursor {
-    fn next(&mut self) -> Option<(&[u8], &[u8])> {
-        if self.just_seeked {
-            self.just_seeked = false;
-        } else if self.iter.valid() {
-            self.iter.next();
-        } else {
-            // Advancing an invalid iterator violates the rocksdb contract, so
-            // an exhausted cursor stays exhausted (until the next seek).
-            return None;
-        }
+    fn current(&self) -> Option<(&[u8], &[u8])> {
         if !self.iter.valid() {
             return None;
         }
-        // SAFETY: the returned slices borrow from `&mut self`; the borrow
-        // checker forbids calling another `&mut self` method (next/seek)
-        // while they're held, which is exactly the rocksdb contract.
+        // SAFETY: `key_inner`/`value_inner` borrow the C++ iterator's own
+        // buffers, which rocksdb invalidates as soon as the iterator moves or is
+        // dropped. The borrow is tied to `&self`; `advance`/`seek` take
+        // `&mut self`, so the borrow checker forbids moving the iterator while a
+        // caller still holds these slices. The safe `key`/`value` accessors copy
+        // into fresh `Vec`s, which is what borrowing here exists to avoid.
         unsafe { Some((self.iter.key_inner()?, self.iter.value_inner()?)) }
+    }
+
+    fn advance(&mut self) {
+        // Advancing an invalid iterator violates the rocksdb contract, so an
+        // exhausted cursor stays exhausted (until the next seek).
+        if self.iter.valid() {
+            self.iter.next();
+        }
     }
 
     fn seek(&mut self, from: SeekFrom) {
@@ -257,6 +250,5 @@ impl CursorBackend for RocksCursor {
             SeekFrom::Start => self.iter.seek_to_first(),
             SeekFrom::Key(key) => self.iter.seek(key),
         }
-        self.just_seeked = true;
     }
 }

--- a/noise-storage/src/lib.rs
+++ b/noise-storage/src/lib.rs
@@ -304,10 +304,22 @@ pub trait BackendSnapshot {
 }
 
 pub trait CursorBackend {
-    fn next(&mut self) -> Option<(&[u8], &[u8])>;
+    /// Returns the key/value at the current position without advancing, or
+    /// `None` when the cursor is exhausted. The slices borrow the cursor and
+    /// are invalidated by the next `advance`/`seek`.
+    fn current(&self) -> Option<(&[u8], &[u8])>;
+    /// Advances to the next entry. A no-op on an already-exhausted cursor.
+    fn advance(&mut self);
     fn seek(&mut self, from: SeekFrom);
 }
 
+/// A forward cursor over key/value entries, positioned *on* an entry (or
+/// exhausted). It is a lending cursor: [`Self::current`] borrows from the
+/// cursor, so the slices are invalidated by the next [`Self::advance`]/
+/// [`Self::seek`]. The `&self`/`&mut self` split lets the borrow checker
+/// enforce that, and lets `current` serve as a zero-copy one-entry lookahead
+/// that survives across stack frames (see `JsonFetcher::do_fetch`): no entry
+/// is advanced past until it has been fully consumed.
 pub struct Cursor {
     inner: Box<dyn CursorBackend>,
 }
@@ -317,14 +329,45 @@ impl Cursor {
         Cursor { inner }
     }
 
-    pub fn seek(&mut self, from: SeekFrom) {
+    /// Positions the cursor and returns the entry it landed on, which is the
+    /// first one at or after `from`, or `None` if there is none.
+    pub fn seek(&mut self, from: SeekFrom) -> Option<(&[u8], &[u8])> {
         self.inner.seek(from);
+        self.inner.current()
     }
 
-    // This is a lending iterator: the returned slices borrow from `&mut self`,
-    // which `std::iter::Iterator` can't express, hence no `Iterator` impl.
-    #[allow(clippy::should_implement_trait)]
-    pub fn next(&mut self) -> Option<(&[u8], &[u8])> {
-        self.inner.next()
+    /// The entry at the current position, or `None` when exhausted. Does not
+    /// advance, so repeated calls yield the same entry until [`Self::advance`].
+    pub fn current(&self) -> Option<(&[u8], &[u8])> {
+        self.inner.current()
+    }
+
+    /// Advances to the next entry.
+    pub fn advance(&mut self) {
+        self.inner.advance();
+    }
+
+    /// Iterates the remaining entries as owned copies. For scans that keep the
+    /// data around anyway; the zero-copy path is [`Self::current`]/
+    /// [`Self::advance`], which is what a lending cursor can't hand to
+    /// [`Iterator`].
+    pub fn entries(&mut self) -> impl Iterator<Item = (Vec<u8>, Vec<u8>)> + '_ {
+        std::iter::from_fn(move || {
+            let (key, value) = self.current()?;
+            let entry = (key.to_vec(), value.to_vec());
+            self.advance();
+            Some(entry)
+        })
+    }
+
+    /// Iterates the keys of the remaining entries as owned copies, leaving the
+    /// values where they are. Same trade-off as [`Self::entries`].
+    pub fn keys(&mut self) -> impl Iterator<Item = Vec<u8>> + '_ {
+        std::iter::from_fn(move || {
+            let (key, _value) = self.current()?;
+            let key = key.to_vec();
+            self.advance();
+            Some(key)
+        })
     }
 }

--- a/noise-tests/src/lib.rs
+++ b/noise-tests/src/lib.rs
@@ -40,17 +40,15 @@ pub fn seq_ordering<D: BackendDatabase>() {
         db.put(key.as_bytes(), b"v").unwrap();
     }
 
-    let mut observed = Vec::new();
     let mut iter = db.iterator();
-    while let Some((key, _)) = iter.next() {
-        let key_str = std::str::from_utf8(key).unwrap();
-        if !key_str.starts_with('W') {
-            continue;
-        }
-        let after_hash = key_str.rsplit('#').next().unwrap();
-        let seq_str = after_hash.trim_end_matches(',');
-        observed.push(seq_str.parse::<u64>().unwrap());
-    }
+    let observed: Vec<u64> = iter
+        .keys()
+        .filter_map(|key| {
+            let key_str = String::from_utf8(key).unwrap();
+            let seq_str = key_str.strip_prefix('W')?.rsplit('#').next().unwrap();
+            Some(seq_str.trim_end_matches(',').parse::<u64>().unwrap())
+        })
+        .collect();
 
     assert_eq!(
         observed, seqs,

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -307,9 +307,7 @@ impl ExactMatchFilter {
         loop {
             let value_key = self.kb.kp_value_key_from_doc_result(&dr);
 
-            self.iter.seek(SeekFrom::Key(value_key.as_bytes()));
-
-            if let Some((key, value)) = self.iter.next() {
+            if let Some((key, value)) = self.iter.seek(SeekFrom::Key(value_key.as_bytes())) {
                 debug_assert!(key.starts_with(value_key.as_bytes())); // must always be true!
                 if let JsonValue::String(string) = JsonFetcher::bytes_to_json_value(value) {
                     let matches = if self.case_sensitive {
@@ -323,12 +321,9 @@ impl ExactMatchFilter {
                         }
                         return Some(dr);
                     } else {
-                        if let Some(next) = self.filter.next_result() {
-                            dr = next;
-                            // continue looping
-                        } else {
-                            return None;
-                        }
+                        let next = self.filter.next_result()?;
+                        dr = next;
+                        // continue looping
                     }
                 } else {
                     panic!("Not a string, wtf!");
@@ -399,6 +394,41 @@ impl RangeFilter {
             term_ordinal: None,
         }
     }
+
+    /// Whether `value` falls within the range. Boolean and null ranges are already decided
+    /// by the key itself, so only numbers get compared against `min`/`max`.
+    fn value_matches(&self, value: &[u8]) -> bool {
+        if matches!(
+            self.min,
+            Some(RangeOperator::True | RangeOperator::False | RangeOperator::Null)
+        ) {
+            // The key already matched, hence it's a valid doc result.
+            return true;
+        }
+
+        // Else it's a range query on numbers
+        let number = unsafe {
+            let array = *(value[..].as_ptr() as *const [_; 8]);
+            f64::from_ne_bytes(array)
+        };
+
+        let min_condition = match self.min {
+            Some(RangeOperator::Inclusive(min)) => number >= min,
+            Some(RangeOperator::Exclusive(min)) => number > min,
+            // No condition was given => it always matches
+            None => true,
+            _ => unreachable!("bool and null ranges returned early"),
+        };
+        let max_condition = match self.max {
+            Some(RangeOperator::Inclusive(max)) => number <= max,
+            Some(RangeOperator::Exclusive(max)) => number < max,
+            // No condition was given => it always matches
+            None => true,
+            _ => unreachable!("bool and null ranges returned early"),
+        };
+
+        min_condition && max_condition
+    }
 }
 
 impl QueryRuntimeFilter for RangeFilter {
@@ -424,57 +454,33 @@ impl QueryRuntimeFilter for RangeFilter {
     }
 
     fn next_result(&mut self) -> Option<DocResult> {
-        while let Some((key, value)) = self.iter.next() {
-            if !key.starts_with(self.keypath.as_bytes()) {
-                // we passed the key path we are interested in. nothing left to do
-                return None;
-            }
-
-            let key_str = unsafe { str::from_utf8_unchecked(key) };
-
-            // The key already matched, hence it's a valid doc result. Return it.
-            if self.min == Some(RangeOperator::True)
-                || self.min == Some(RangeOperator::False)
-                || self.min == Some(RangeOperator::Null)
-            {
-                let mut dr = KeyBuilder::parse_doc_result_from_kp_word_key(key_str);
-                if let Some(to) = self.term_ordinal {
-                    dr.add_score(to, 1.0);
+        loop {
+            // The cursor's slices are invalidated by `advance()`, so the entry is read out
+            // completely here and only the owned `DocResult` leaves the block.
+            let doc_result = {
+                let (key, value) = self.iter.current()?;
+                if !key.starts_with(self.keypath.as_bytes()) {
+                    // we passed the key path we are interested in. nothing left to do
+                    return None;
                 }
-                return Some(dr);
-            }
-            // Else it's a range query on numbers
-
-            let number = unsafe {
-                let array = *(value[..].as_ptr() as *const [_; 8]);
-                f64::from_ne_bytes(array)
-            };
-
-            let min_condition = match self.min {
-                Some(RangeOperator::Inclusive(min)) => number >= min,
-                Some(RangeOperator::Exclusive(min)) => number > min,
-                // No condition was given => it always matches
-                None => true,
-                _ => panic!("Can't happen, it returns early on the other types"),
-            };
-            let max_condition = match self.max {
-                Some(RangeOperator::Inclusive(max)) => number <= max,
-                Some(RangeOperator::Exclusive(max)) => number < max,
-                // No condition was given => it always matches
-                None => true,
-                _ => panic!("Can't happen, it returns early on the other types"),
-            };
-
-            if min_condition && max_condition {
-                let mut dr = KeyBuilder::parse_doc_result_from_kp_word_key(key_str);
-                if let Some(to) = self.term_ordinal {
-                    dr.add_score(to, 1.0);
+                if self.value_matches(value) {
+                    let key_str = unsafe { str::from_utf8_unchecked(key) };
+                    Some(KeyBuilder::parse_doc_result_from_kp_word_key(key_str))
+                } else {
+                    None
                 }
-                return Some(dr);
+            };
+            self.iter.advance();
+
+            // No match => move on to the next key
+            let Some(mut dr) = doc_result else {
+                continue;
+            };
+            if let Some(to) = self.term_ordinal {
+                dr.add_score(to, 1.0);
             }
-            // Else: No match => KKeep looping and move on to the next key
+            return Some(dr);
         }
-        None
     }
 
     // TODO vmx 2017-04-13: Scoring is not implemented yet
@@ -539,28 +545,26 @@ impl<S: BackendSnapshot> QueryRuntimeFilter for BboxFilter<S> {
 
     fn next_result(&mut self) -> Option<DocResult> {
         let iter = self.iter.as_mut().unwrap();
-        if let Some((key, value)) = iter.next() {
-            let mut vec = Vec::with_capacity(key.len());
-            vec.extend_from_slice(key);
-            let mut read = Cursor::new(vec);
-            let key_len = read.read_unsigned_varint_32().unwrap();
-            let offset = read.position() as usize;
+        let (key, value) = iter.current()?;
+        let mut vec = Vec::with_capacity(key.len());
+        vec.extend_from_slice(key);
+        let mut read = Cursor::new(vec);
+        let key_len = read.read_unsigned_varint_32().unwrap();
+        let offset = read.position() as usize;
 
-            let iid = unsafe {
-                let array = *(key[offset + key_len as usize..].as_ptr() as *const [_; 8]);
-                u64::from_ne_bytes(array)
-            };
+        let iid = unsafe {
+            let array = *(key[offset + key_len as usize..].as_ptr() as *const [_; 8]);
+            u64::from_ne_bytes(array)
+        };
 
-            let mut dr = DocResult::new();
-            dr.seq = iid;
-            dr.arraypath = Self::from_u8_slice(value);
-            if let Some(to) = self.term_ordinal {
-                dr.add_score(to, 1.0);
-            }
-            Some(dr)
-        } else {
-            None
+        let mut dr = DocResult::new();
+        dr.seq = iid;
+        dr.arraypath = Self::from_u8_slice(value);
+        iter.advance();
+        if let Some(to) = self.term_ordinal {
+            dr.add_score(to, 1.0);
         }
+        Some(dr)
     }
 
     fn prepare_relevancy_scoring(&mut self, qsi: &mut QueryScoringInfo) {
@@ -965,8 +969,7 @@ impl NotFilter {
                 // if not, it means other elements did a regular match and skipped them, then we
                 // ran off the end of the array.
                 let value_key = self.kb.kp_value_key_from_doc_result(dr);
-                self.iter.seek(SeekFrom::Key(value_key.as_bytes()));
-                if let Some((key, _value)) = self.iter.next() {
+                if let Some((key, _value)) = self.iter.seek(SeekFrom::Key(value_key.as_bytes())) {
                     let key_str = unsafe { str::from_utf8_unchecked(key) };
                     KeyBuilder::is_kp_value_key_prefix(&value_key, key_str)
                 } else {
@@ -983,8 +986,7 @@ impl NotFilter {
             let mut kb = KeyBuilder::new();
             kb.push_object_key("_id");
             let value_key = kb.kp_value_key_from_doc_result(dr);
-            self.iter.seek(SeekFrom::Key(value_key.as_bytes()));
-            if let Some((key, _value)) = self.iter.next() {
+            if let Some((key, _value)) = self.iter.seek(SeekFrom::Key(value_key.as_bytes())) {
                 let key_str = unsafe { str::from_utf8_unchecked(key) };
                 value_key == key_str
             } else {

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,7 +1,7 @@
 extern crate uuid;
 
 use self::uuid::Uuid;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::HashSet;
 use std::io::Write;
 use std::str;
 
@@ -158,19 +158,14 @@ impl<D: BackendDatabase> Index<D> {
             // collect up all the fields for the existing doc
             let kb = KeyBuilder::new();
             let value_key = kb.kp_value_key(seq);
-            let mut key_values = BTreeMap::new();
-
             let mut iter = self.db.iterator();
             // Seek in index to >= entry
             iter.seek(SeekFrom::Key(value_key.as_bytes()));
-            while let Some((key, value)) = iter.next() {
-                if !key.starts_with(value_key.as_bytes()) {
-                    break;
-                }
-                let key = unsafe { str::from_utf8_unchecked(key) }.to_string();
-                let value = value.to_vec();
-                key_values.insert(key, value);
-            }
+            let key_values: KeyValues = iter
+                .entries()
+                .take_while(|(key, _value)| key.starts_with(value_key.as_bytes()))
+                .map(|(key, value)| (unsafe { String::from_utf8_unchecked(key) }, value))
+                .collect();
             Ok(Some((seq, key_values)))
         } else {
             Ok(None)
@@ -190,13 +185,11 @@ impl<D: BackendDatabase> Index<D> {
     }
 
     pub fn all_keys(&self) -> Result<Vec<String>, Error> {
-        let mut results = Vec::new();
         let mut iter = self.db.iterator();
-        while let Some((key, _value)) = iter.next() {
-            let key_string = unsafe { str::from_utf8_unchecked(key) }.to_string();
-            results.push(key_string);
-        }
-        Ok(results)
+        Ok(iter
+            .keys()
+            .map(|key| unsafe { String::from_utf8_unchecked(key) })
+            .collect())
     }
 
     pub fn fetch_seq(&self, id: &str) -> Result<Option<u64>, Error> {
@@ -254,13 +247,25 @@ mod tests {
     use crate::json_value::JsonValue;
     use crate::snapshot::JsonFetcher;
     use crate::test_backend::Database;
-    use noise_storage::BackendDatabase;
-    use std::str;
+    use noise_storage::{BackendDatabase, Cursor};
     use std::sync::mpsc::channel;
     use std::sync::Arc;
     use std::thread;
 
     type Idx = Index<Database>;
+
+    /// The value entries the cursor still has ahead of it, decoded.
+    fn value_entries(iter: &mut Cursor) -> Vec<(String, JsonValue)> {
+        iter.entries()
+            .filter(|(key, _value)| key[0] as char == 'V')
+            .map(|(key, value)| {
+                (
+                    unsafe { String::from_utf8_unchecked(key) },
+                    JsonFetcher::bytes_to_json_value(&value),
+                )
+            })
+            .collect()
+    }
 
     #[test]
     fn test_open() {
@@ -310,9 +315,9 @@ mod tests {
         index.db.compact();
 
         let mut iter = index.db.iterator();
-        let (key, _value) = iter.next().unwrap();
-        assert!(key.starts_with(&b"HDB"[..]));
-        assert!(iter.next().is_none());
+        let mut keys = iter.keys();
+        assert!(keys.next().unwrap().starts_with(b"HDB"));
+        assert!(keys.next().is_none());
     }
 
     #[test]
@@ -332,14 +337,8 @@ mod tests {
 
         index.flush(batch).unwrap();
         {
-            let mut results = Vec::new();
             let mut iter = index.db.iterator();
-            while let Some((key, value)) = iter.next() {
-                if key[0] as char == 'V' {
-                    let key_string = unsafe { str::from_utf8_unchecked(key) }.to_string();
-                    results.push((key_string, JsonFetcher::bytes_to_json_value(value)));
-                }
-            }
+            let results = value_entries(&mut iter);
 
             let expected = vec![
                 ("V1#._id".to_string(), JsonValue::String("1".to_string())),
@@ -362,14 +361,8 @@ mod tests {
             .unwrap();
         index.flush(batch).unwrap();
 
-        let mut results = Vec::new();
         let mut iter = index.db.iterator();
-        while let Some((key, value)) = iter.next() {
-            if key[0] as char == 'V' {
-                let key_string = unsafe { str::from_utf8_unchecked(key) }.to_string();
-                results.push((key_string, JsonFetcher::bytes_to_json_value(value)));
-            }
-        }
+        let results = value_entries(&mut iter);
         let expected = vec![
             ("V1#._id".to_string(), JsonValue::String("1".to_string())),
             ("V1#.baz".to_string(), JsonValue::Array(vec![])),

--- a/src/json_shred.rs
+++ b/src/json_shred.rs
@@ -578,7 +578,6 @@ mod tests {
     use self::varint::VarintRead;
 
     use std::io::Cursor;
-    use std::str;
 
     use crate::index::{Index, OpenOptions};
     use crate::json_value::JsonValue;
@@ -589,34 +588,31 @@ mod tests {
     type Idx = Index<Database>;
 
     fn positions_from_db(db: &Database) -> Vec<(String, Vec<u32>)> {
-        let mut result = Vec::new();
         let mut iter = db.iterator();
-        while let Some((key, value)) = iter.next() {
-            if key[0] as char == 'W' {
-                let mut vec = Vec::with_capacity(value.len());
-                vec.extend(value.iter());
-                let mut bytes = Cursor::new(vec);
+        iter.entries()
+            .filter(|(key, _value)| key[0] as char == 'W')
+            .map(|(key, value)| {
+                let mut bytes = Cursor::new(value);
                 let mut positions = Vec::new();
                 while let Ok(pos) = bytes.read_unsigned_varint_32() {
                     positions.push(pos);
                 }
-                let key_string = unsafe { str::from_utf8_unchecked(key) }.to_string();
-                result.push((key_string, positions));
-            }
-        }
-        result
+                (unsafe { String::from_utf8_unchecked(key) }, positions)
+            })
+            .collect()
     }
 
     fn values_from_db(db: &Database) -> Vec<(String, JsonValue)> {
-        let mut result = Vec::new();
         let mut iter = db.iterator();
-        while let Some((key, value)) = iter.next() {
-            if key[0] as char == 'V' {
-                let key_string = unsafe { str::from_utf8_unchecked(key) }.to_string();
-                result.push((key_string, JsonFetcher::bytes_to_json_value(value)));
-            }
-        }
-        result
+        iter.entries()
+            .filter(|(key, _value)| key[0] as char == 'V')
+            .map(|(key, value)| {
+                (
+                    unsafe { String::from_utf8_unchecked(key) },
+                    JsonFetcher::bytes_to_json_value(&value),
+                )
+            })
+            .collect()
     }
 
     #[test]

--- a/src/query.rs
+++ b/src/query.rs
@@ -546,11 +546,8 @@ impl<S: BackendSnapshot + 'static> QueryResults<S> {
                                 }
                             }
                         }
-                        if let Some(mut results) = self.ordered_buffer.pop() {
-                            return Some(self.returnable.json_result(&mut results));
-                        } else {
-                            return None;
-                        }
+                        let mut results = self.ordered_buffer.pop()?;
+                        return Some(self.returnable.json_result(&mut results));
                     }
                 }
             }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -11,43 +11,6 @@ use crate::query::{DocResult, QueryScoringInfo};
 use crate::returnable::{PathSegment, ReturnPath};
 use noise_storage::{convert_bytes_to_i32, BackendSnapshot, Cursor, SeekFrom};
 
-/// One-step lookahead over a `Cursor`. `Cursor::next` lends out slices that
-/// borrow from `&mut self`, so `Cursor` cannot implement `Iterator` and the
-/// standard `Peekable` adapter is not usable with it. `PeekCursor` provides
-/// the same lookahead by owning the peeked pair, so the borrow on the
-/// underlying cursor ends between `peek()` and the next operation.
-struct PeekCursor<'a> {
-    inner: &'a mut Cursor,
-    peeked: Option<(Vec<u8>, Vec<u8>)>,
-}
-
-impl<'a> PeekCursor<'a> {
-    fn new(inner: &'a mut Cursor) -> Self {
-        Self {
-            inner,
-            peeked: None,
-        }
-    }
-
-    fn peek(&mut self) -> Option<(&[u8], &[u8])> {
-        if self.peeked.is_none() {
-            if let Some((k, v)) = self.inner.next() {
-                self.peeked = Some((k.to_vec(), v.to_vec()));
-            }
-        }
-        self.peeked
-            .as_ref()
-            .map(|(k, v)| (k.as_slice(), v.as_slice()))
-    }
-
-    fn next(&mut self) -> Option<(Vec<u8>, Vec<u8>)> {
-        if let Some(pair) = self.peeked.take() {
-            return Some(pair);
-        }
-        self.inner.next().map(|(k, v)| (k.to_vec(), v.to_vec()))
-    }
-}
-
 pub struct Snapshot<S: BackendSnapshot> {
     snap: S,
 }
@@ -114,24 +77,16 @@ impl DocResultIterator {
     }
 
     pub fn next(&mut self) -> Option<(DocResult, TermPositions)> {
-        if let Some((key, value)) = self.iter.next() {
-            if !key.starts_with(self.keypathword.as_bytes()) {
-                // we passed the key path we are interested in. nothing left to do */
-                return None;
-            }
-
-            let key_str = unsafe { str::from_utf8_unchecked(key) };
-            let dr = KeyBuilder::parse_doc_result_from_kp_word_key(key_str);
-
-            Some((
-                dr,
-                TermPositions {
-                    pos: value.to_vec(),
-                },
-            ))
-        } else {
-            None
+        let (key, value) = self.iter.current()?;
+        if !key.starts_with(self.keypathword.as_bytes()) {
+            // we passed the key path we are interested in. nothing left to do
+            return None;
         }
+        let key_str = unsafe { str::from_utf8_unchecked(key) };
+        let dr = KeyBuilder::parse_doc_result_from_kp_word_key(key_str);
+        let pos = value.to_vec();
+        self.iter.advance();
+        Some((dr, TermPositions { pos }))
     }
 }
 
@@ -182,8 +137,7 @@ impl Scorer {
     }
 
     pub fn get_value(&mut self, key: &str) -> Option<Box<[u8]>> {
-        self.iter.seek(SeekFrom::Key(key.as_bytes()));
-        if let Some((ret_key, ret_value)) = self.iter.next() {
+        if let Some((ret_key, ret_value)) = self.iter.seek(SeekFrom::Key(key.as_bytes())) {
             if ret_key.len() == key.len() && ret_key.starts_with(key.as_bytes()) {
                 Some(ret_value.to_vec().into_boxed_slice())
             } else {
@@ -290,9 +244,9 @@ impl JsonFetcher {
                             kb.pop_array();
 
                             // Seek in index to >= entry
-                            iter.seek(SeekFrom::Key(value_key.as_bytes()));
-
-                            if let Some((key, _value)) = iter.next() {
+                            if let Some((key, _value)) =
+                                iter.seek(SeekFrom::Key(value_key.as_bytes()))
+                            {
                                 if key.starts_with(value_key.as_bytes()) {
                                     // yes it exists. loop again.
                                     continue;
@@ -316,24 +270,15 @@ impl JsonFetcher {
         let value_key = kb.kp_value_key(seq);
 
         // Seek in index to >= entry
-        iter.seek(SeekFrom::Key(value_key.as_bytes()));
-
-        let (key, value) = match iter.next() {
-            Some((key, value)) => (key.to_vec(), value.to_vec()),
-            None => return None,
-        };
-
-        if !KeyBuilder::is_kp_value_key_prefix(&value_key, unsafe {
-            str::from_utf8_unchecked(&key)
-        }) {
+        let (key, _value) = iter.seek(SeekFrom::Key(value_key.as_bytes()))?;
+        let key_str = unsafe { str::from_utf8_unchecked(key) };
+        if !KeyBuilder::is_kp_value_key_prefix(&value_key, key_str) {
+            // the cursor landed past the keypath, there is no value to fetch
             return None;
         }
-        Some(JsonFetcher::do_fetch(
-            &mut PeekCursor::new(iter),
-            &value_key,
-            key,
-            value,
-        ))
+
+        // The cursor is still on that entry, which is where `do_fetch` starts reading.
+        Some(JsonFetcher::do_fetch(iter, &value_key))
     }
 
     /// When do_fetch is called it means we know we are going to find a value because
@@ -341,111 +286,101 @@ impl JsonFetcher {
     /// keypath to figure out the nested structure of the remaining keypath. So we
     /// depth first recursively parse the keypath and return the value and inserting into
     /// containers (arrays or objects) then iterate keys until the keypath no longer matches.
-    fn do_fetch(
-        iter: &mut PeekCursor<'_>,
-        value_key: &str,
-        mut key: Vec<u8>,
-        mut value: Vec<u8>,
-    ) -> JsonValue {
+    ///
+    /// The cursor is read in place: on entry it is positioned on the first index entry of
+    /// this subtree, and on return it has been advanced just past the subtree (a scalar leaf
+    /// advances once; a container leaves the cursor wherever its deepest leaf did). No entry
+    /// is advanced past until it has been fully consumed, so the cursor's own position is the
+    /// one-entry lookahead that the whole recursion shares.
+    fn do_fetch(iter: &mut Cursor, value_key: &str) -> JsonValue {
+        let (key, value) = iter.current().expect("cursor not to be exhausted");
         if key.len() == value_key.len() {
-            // we have a key match!
-            return JsonFetcher::bytes_to_json_value(value.as_ref());
+            // we have a key match! Consume the leaf and move past it.
+            let json = JsonFetcher::bytes_to_json_value(value);
+            iter.advance();
+            return json;
         }
-        let segment = {
-            let key_str = unsafe { str::from_utf8_unchecked(&key) };
-            let remaining = &key_str[value_key.len()..];
-            KeyBuilder::parse_first_kp_value_segment(remaining)
-        };
+        let key_str = unsafe { str::from_utf8_unchecked(key) };
+        // The segment is owned, so the cursor borrow ends here and the recursion below is
+        // free to advance the cursor.
+        let segment = KeyBuilder::parse_first_kp_value_segment(&key_str[value_key.len()..]);
 
         match segment {
-            Some((Segment::ObjectKey(mut unescaped), escaped)) => {
-                let mut object: Vec<(String, JsonValue)> = Vec::new();
-
-                let mut value_key_next = value_key.to_string() + &escaped;
-                loop {
-                    let json_val = JsonFetcher::do_fetch(iter, &value_key_next, key, value);
-                    object.push((unescaped, json_val));
-
-                    let segment = match iter.peek() {
-                        Some((k, _v)) => {
-                            let key = unsafe { str::from_utf8_unchecked(k) };
-                            if !KeyBuilder::is_kp_value_key_prefix(value_key, key) {
-                                return JsonValue::Object(object);
-                            }
-
-                            let key_str = unsafe { str::from_utf8_unchecked(k) };
-                            let remaining = &key_str[value_key.len()..];
-
-                            KeyBuilder::parse_first_kp_value_segment(remaining)
-                        }
-                        None => return JsonValue::Object(object),
-                    };
-
-                    if let Some((Segment::ObjectKey(unescaped2), escaped2)) = segment {
-                        unescaped = unescaped2;
-                        // advance the peeked iter
-                        match iter.next() {
-                            Some((k, v)) => {
-                                key = k;
-                                value = v;
-                            }
-                            None => panic!("couldn't advanced already peeked iter"),
-                        };
-                        value_key_next.truncate(value_key.len());
-                        value_key_next.push_str(&escaped2);
-                    } else {
-                        return JsonValue::Object(object);
-                    }
-                }
+            Some((Segment::ObjectKey(unescaped), escaped)) => {
+                JsonFetcher::fetch_object(iter, value_key, unescaped, escaped)
             }
-            Some((Segment::Array(mut i), escaped)) => {
-                // we use a tuple with ordinal because we encounter
-                // elements in lexical sorting order instead of ordinal order
-                let mut array: Vec<(u64, JsonValue)> = Vec::new();
-
-                let mut value_key_next = value_key.to_string() + &escaped;
-                loop {
-                    let json_val = JsonFetcher::do_fetch(iter, &value_key_next, key, value);
-                    array.push((i, json_val));
-
-                    let segment = match iter.peek() {
-                        Some((k, _v)) => {
-                            let key = unsafe { str::from_utf8_unchecked(k) };
-                            if !KeyBuilder::is_kp_value_key_prefix(value_key, key) {
-                                return JsonFetcher::return_array(array);
-                            }
-
-                            let key_str = unsafe { str::from_utf8_unchecked(k) };
-                            let remaining = &key_str[value_key.len()..];
-
-                            KeyBuilder::parse_first_kp_value_segment(remaining)
-                        }
-                        None => return JsonFetcher::return_array(array),
-                    };
-
-                    if let Some((Segment::Array(i2), escaped2)) = segment {
-                        i = i2;
-                        // advance the already peeked iter
-                        match iter.next() {
-                            Some((k, v)) => {
-                                key = k;
-                                value = v;
-                            }
-                            None => panic!("couldn't advanced already peeked iter"),
-                        };
-                        value_key_next.truncate(value_key.len());
-                        value_key_next.push_str(&escaped2);
-                    } else {
-                        return JsonFetcher::return_array(array);
-                    }
-                }
+            Some((Segment::Array(index), escaped)) => {
+                JsonFetcher::fetch_array(iter, value_key, index, escaped)
             }
-            None => {
-                let key_str = unsafe { str::from_utf8_unchecked(&key) };
-                panic!(
-                    "somehow couldn't parse key segment {} {}",
-                    value_key, key_str
-                );
+            None => panic!("somehow couldn't parse key segment {}", value_key),
+        }
+    }
+
+    /// The first keypath segment of the entry the cursor is on, relative to `value_key`, or
+    /// `None` if the cursor is exhausted or has moved past the `value_key` subtree.
+    fn current_segment(iter: &Cursor, value_key: &str) -> Option<(Segment, String)> {
+        let (key, _value) = iter.current()?;
+        let key_str = unsafe { str::from_utf8_unchecked(key) };
+        if !KeyBuilder::is_kp_value_key_prefix(value_key, key_str) {
+            return None;
+        }
+        KeyBuilder::parse_first_kp_value_segment(&key_str[value_key.len()..])
+    }
+
+    /// Fetches the object at `value_key`, whose first key is the already-parsed segment
+    /// `unescaped`/`escaped`. Ends at the first entry that isn't another key of this object.
+    fn fetch_object(
+        iter: &mut Cursor,
+        value_key: &str,
+        mut unescaped: String,
+        mut escaped: String,
+    ) -> JsonValue {
+        let mut object: Vec<(String, JsonValue)> = Vec::new();
+        let mut child_key = value_key.to_string();
+        loop {
+            // `child_key` is reused across the keys, so reset it to `value_key` before
+            // appending this key's segment
+            child_key.truncate(value_key.len());
+            child_key.push_str(&escaped);
+            object.push((unescaped, JsonFetcher::do_fetch(iter, &child_key)));
+
+            // `do_fetch` left the cursor on the first entry beyond the child's subtree.
+            match JsonFetcher::current_segment(iter, value_key) {
+                Some((Segment::ObjectKey(next_unescaped), next_escaped)) => {
+                    unescaped = next_unescaped;
+                    escaped = next_escaped;
+                }
+                _ => return JsonValue::Object(object),
+            }
+        }
+    }
+
+    /// Fetches the array at `value_key`, whose first element is the already-parsed segment
+    /// `index`/`escaped`. Ends at the first entry that isn't another element of this array.
+    fn fetch_array(
+        iter: &mut Cursor,
+        value_key: &str,
+        mut index: u64,
+        mut escaped: String,
+    ) -> JsonValue {
+        // we keep the ordinal because we encounter elements in lexical sorting order
+        // instead of ordinal order, `return_array` sorts them
+        let mut array: Vec<(u64, JsonValue)> = Vec::new();
+        let mut child_key = value_key.to_string();
+        loop {
+            // `child_key` is reused across the elements, so reset it to `value_key` before
+            // appending this element's segment
+            child_key.truncate(value_key.len());
+            child_key.push_str(&escaped);
+            array.push((index, JsonFetcher::do_fetch(iter, &child_key)));
+
+            // `do_fetch` left the cursor on the first entry beyond the element's subtree.
+            match JsonFetcher::current_segment(iter, value_key) {
+                Some((Segment::Array(next_index), next_escaped)) => {
+                    index = next_index;
+                    escaped = next_escaped;
+                }
+                _ => return JsonFetcher::return_array(array),
             }
         }
     }
@@ -457,18 +392,12 @@ pub struct AllDocsIterator {
 
 impl AllDocsIterator {
     pub fn next(&mut self) -> Option<DocResult> {
-        match self.iter.next() {
-            Some((k, _v)) => {
-                let key = unsafe { str::from_utf8_unchecked(k) };
-                if let Some(seq) = KeyBuilder::parse_seq_key(key) {
-                    let mut dr = DocResult::new();
-                    dr.seq = seq;
-                    Some(dr)
-                } else {
-                    None
-                }
-            }
-            None => None,
-        }
+        let (key, _value) = self.iter.current()?;
+        let key_str = unsafe { str::from_utf8_unchecked(key) };
+        let seq = KeyBuilder::parse_seq_key(key_str)?;
+        self.iter.advance();
+        let mut dr = DocResult::new();
+        dr.seq = seq;
+        Some(dr)
     }
 }


### PR DESCRIPTION
`CursorBackend::next()` consumed the entry it returned, so `JsonFetcher` needed `PeekCursor` to buffer an owned copy for the one-entry lookahead it carries across recursion levels. Splitting it into `current()`/`advance()` makes the cursor's own position that lookahead: `current()` borrows the entry (`&self`), `advance()` moves on (`&mut self`), so the borrow checker enforces that the slices die when the cursor moves. The buffer, the per-entry `to_vec()`s in the fetch path and `RocksCursor::just_seeked` all go with it.

`do_fetch` now reads in place and splits into `current_segment`, `fetch_object` and `fetch_array`; `Cursor` gains `seek()` returning the entry it landed on, and `entries()`/`keys()` for the scans that keep owned copies anyway.